### PR TITLE
Feature/google form

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,7 @@ import LogTable from './components/logTable/logTable.js';
 import MapAndDataContainer from './components/MapAndDataContainer/MapAndDataContainer.js';
 import Header from './components/Header/Header.js';
 import LandingPage from './components/LandingPage/LandingPage.js';
+import QaPanel from './components/qaPanel/qaPanel.js';
 
 class App extends React.Component {
 
@@ -29,6 +30,7 @@ class App extends React.Component {
           <Container>
             <Header />
             <LogTable/>
+            <QaPanel/>
             <MapAndDataContainer/>
           </Container>
         </React.Fragment>

--- a/src/components/qaPanel/qaPanel.css
+++ b/src/components/qaPanel/qaPanel.css
@@ -1,0 +1,13 @@
+.qaPanel {}
+
+.googleForm{
+    left: 250px;
+    position: absolute;
+    z-index:1;
+    bottom: 20px;
+    /* border: black solid 2px; */
+    background-color: white;
+    border-radius: 1%;
+    box-shadow: 0px 0px 5px 1px rgb(189, 189, 189);
+    /* box-shadow: 10px grey; */
+}

--- a/src/components/qaPanel/qaPanel.js
+++ b/src/components/qaPanel/qaPanel.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import './qaPanel.css';
+
+class QaPanel extends React.Component {
+  render() {
+      return(
+        <iframe className='googleForm' title='Peer Learning Activity' src="https://docs.google.com/forms/d/e/1FAIpQLSfHF_EJAfLIodzHOImewciEIAJomAsrKbXvYDRu27n6DyMtaQ/viewform?embedded=true" width="640" height="200" frameBorder="0" marginHeight="0" marginWidth="0">Loading…</iframe>
+      )
+  }
+}
+
+//in the future, use className freebirdFormviewerComponentsQuestionBaseDescription and get the first character in the string to get the number of allowed items to log, then post message it up. 
+
+export default QaPanel;

--- a/src/components/qaPanel/qaPanel.test.js
+++ b/src/components/qaPanel/qaPanel.test.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import qaPanel from './qaPanel';
+
+describe('<qaPanel />', () => {
+  test('it should mount', () => {
+    render(<qaPanel />);
+    
+    const qaPanel = screen.getByTestId('qaPanel');
+
+    expect(qaPanel).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Here's an iframe with a google form in it. I'm thinking if Peter just includes the number of allowed items to log in the description of the question, we will be able to use it to put more control on the log table. I'm thinking I can add a component that lists out the past log tables? Or something like that, depending on what Peter wanted, I'd have to go look back into my notes to see if that's what he said he wanted. Obviously this shows all the questions at once, but we can look into figuring it out in the future; this seems like the most logical step for right now at least. 